### PR TITLE
Fix for work darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
           workDarwin = import ./hosts/workDarwin {
             inherit inputs;
             username = inputs.workUsername.value;
+            brewUsername = inputs.workUsername.brewUser;
           };
         };
       };

--- a/home-manager/packages/work.nix
+++ b/home-manager/packages/work.nix
@@ -1,7 +1,6 @@
 { pkgs }:
 with pkgs;
 [
-  _1password-gui
   _1password-cli
   zoom-us
   awscli2

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -14,6 +14,7 @@ in
   programs.zsh = {
     enable = true;
     enableCompletion = true;
+    completionInit = "autoload -U compinit && compinit -u";
     autosuggestion = {
       enable = true;
     };

--- a/hosts/workDarwin/default.nix
+++ b/hosts/workDarwin/default.nix
@@ -1,4 +1,8 @@
-{ inputs, username }:
+{
+  inputs,
+  username,
+  brewUsername,
+}:
 let
   inherit (inputs)
     nix-darwin
@@ -26,7 +30,7 @@ nix-darwin.lib.darwinSystem {
   inherit pkgs;
   inherit (inputs.nixpkgs) lib;
   specialArgs = {
-    inherit username pkgs;
+    inherit username brewUsername pkgs;
   };
   modules = [
     configuration

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -7,7 +7,6 @@
     };
     casks = [
       "karabiner-elements"
-      "google-chrome"
       "logi-options+"
     ];
   };

--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -18,7 +18,7 @@
         show-recents = false;
         launchanim = false;
         orientation = "bottom";
-        wvous-br-corner = 4;
+        wvous-br-corner = 2;
       };
       controlcenter = {
         Bluetooth = true;

--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -18,6 +18,7 @@
         show-recents = false;
         launchanim = false;
         orientation = "bottom";
+        wvous-br-corner = 4;
       };
       controlcenter = {
         Bluetooth = true;

--- a/nix-darwin/config/zsh.nix
+++ b/nix-darwin/config/zsh.nix
@@ -1,0 +1,3 @@
+{
+  programs.zsh.enableGlobalCompInit = false;
+}

--- a/nix-darwin/work.nix
+++ b/nix-darwin/work.nix
@@ -2,16 +2,10 @@
 {
   imports = [
     ./default.nix
+    ./config/zsh.nix
   ];
 
   environment.etc."ssl/certs/ca-certificates.crt".enable = false;
 
   nix.settings.ssl-cert-file = "/etc/ssl/certs/ca-certificates.crt";
-
-  homebrew = {
-    casks = [
-      "windows-app"
-      "microsoft-teams"
-    ];
-  };
 }

--- a/nix-darwin/work.nix
+++ b/nix-darwin/work.nix
@@ -12,4 +12,7 @@
   # darwin-rebuild 実行ユーザーと適用させたいユーザーが異なるときに
   # /opt/homebrew の所有者と一致させて実行させる。
   homebrew.user = brewUsername;
+  homebrew.casks = [
+    "1password"
+  ];
 }

--- a/nix-darwin/work.nix
+++ b/nix-darwin/work.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ brewUsername, ... }:
 {
   imports = [
     ./default.nix
@@ -8,4 +8,8 @@
   environment.etc."ssl/certs/ca-certificates.crt".enable = false;
 
   nix.settings.ssl-cert-file = "/etc/ssl/certs/ca-certificates.crt";
+
+  # darwin-rebuild 実行ユーザーと適用させたいユーザーが異なるときに
+  # /opt/homebrew の所有者と一致させて実行させる。
+  homebrew.user = brewUsername;
 }

--- a/users/work/flake.nix
+++ b/users/work/flake.nix
@@ -10,16 +10,25 @@
 
         Please create your username configuration:
 
-        cat > nix/users/work/flake.nix << 'EOF'
+        cat > users/work/flake.nix << 'EOF'
         {
           description = "Work username configuration";
           outputs = { self }: {
             value = "your_username_here";
+            brewUser = "your_brew_username_here";
           };
         }
         EOF
 
-        Replace "your_username_here" with your actual username.
+        Replace "your_username_here" with your actual username,
+        and "your_brew_username_here" with the owner of /opt/homebrew.
+      '';
+      brewUser = builtins.throw ''
+        ============================================
+        ERROR: Brew username not configured for workDarwin
+        ============================================
+
+        Please set brewUser in users/work/flake.nix to the owner of /opt/homebrew.
       '';
     };
 }


### PR DESCRIPTION
### Summary

* brew 実行ユーザーと利用ユーザーが異なる場合、`homebrew.user`の設定が必要
* Nixのデフォルトzshrcのユーザーが利用ユーザーと異なる場合、compauditが反応するため無視するように設定
* 1Password GUIのMac版はない、かつ初回起動時にApplication直下にある必要があるためbrew(nix-darwin)に移動
* ホットコーナーの設定を追加